### PR TITLE
Remove unnecessary routerFunction from config

### DIFF
--- a/src/main/java/org/example/springgraphqldefer/AppConfiguration.java
+++ b/src/main/java/org/example/springgraphqldefer/AppConfiguration.java
@@ -8,24 +8,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.graphql.server.WebGraphQlHandler;
 import org.springframework.graphql.server.WebGraphQlInterceptor;
+import org.springframework.graphql.server.webflux.GraphQlHttpHandler;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.web.reactive.config.CorsRegistry;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
-import org.springframework.web.reactive.function.server.RequestPredicates;
-import org.springframework.web.reactive.function.server.RouterFunction;
-import org.springframework.web.reactive.function.server.RouterFunctions;
-import org.springframework.web.reactive.function.server.ServerResponse;
 
 @Configuration(proxyBeanMethods = false)
 public class AppConfiguration implements WebFluxConfigurer {
 
     @Bean
-    public RouterFunction<ServerResponse> routerFunction(ExtendedGraphQlHttpHandler handler) {
-        return RouterFunctions.route(RequestPredicates.path("/graphql"), handler::handleRequest);
-    }
-
-    @Bean
-    public ExtendedGraphQlHttpHandler graphQlHttpHandler(WebGraphQlHandler handler, ServerCodecConfigurer configurer) {
+    public GraphQlHttpHandler graphQlHttpHandler(WebGraphQlHandler handler, ServerCodecConfigurer configurer) {
         return new ExtendedGraphQlHttpHandler(handler, configurer);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,4 @@
 spring.graphql.graphiql.enabled=true
-# the real path is mapped in the code inside the routing configuration class
-spring.graphql.path=/void
 
 logging.level.org.example.springgraphqldefer=DEBUG
 logging.level.org.springframework.web=DEBUG


### PR DESCRIPTION
There is no need to create a routerFunction. Simply overriding the `GraphQlHttpHandler` bean is sufficient. The Boot starter uses that instead, and prepares the routing.